### PR TITLE
Add initial Docker support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+ version: '2'
+ services:
+   approval:
+     build: microservice-approval/
+     ports:
+       - "3000:3000"
+   reservations:
+      build: microservice-reservations/
+      ports:
+       - "3001:3001"
+   servers:
+      build: microservice-servers/
+      ports:
+       - "3002:3002"
+   updater:
+      build: microservice-updater/
+      ports:
+       - "3003:3003"

--- a/microservice-approval/Dockerfile
+++ b/microservice-approval/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:argon
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+COPY package.json /usr/src/app
+
+RUN npm install
+
+RUN npm install async
+RUN npm install -g --force nodemon
+
+COPY . /usr/src/app
+
+EXPOSE 3000
+
+CMD ["nodemon", "."]

--- a/microservice-reservations/Dockerfile
+++ b/microservice-reservations/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:argon
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+COPY package.json /usr/src/app
+
+RUN npm install
+
+RUN npm install -g --force nodemon
+
+COPY . /usr/src/app
+
+EXPOSE 3001
+
+CMD ["nodemon", "."]

--- a/microservice-servers/Dockerfile
+++ b/microservice-servers/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:argon
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+COPY package.json /usr/src/app
+
+RUN npm install
+
+RUN npm install -g --force nodemon
+
+COPY . /usr/src/app
+
+EXPOSE 3002
+
+CMD ["nodemon", "."]

--- a/microservice-updater/Dockerfile
+++ b/microservice-updater/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:argon
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+COPY package.json /usr/src/app
+
+RUN npm install
+
+RUN npm install async
+RUN npm install -g --force nodemon
+
+COPY . /usr/src/app
+
+EXPOSE 3003
+
+CMD ["nodemon", "."]


### PR DESCRIPTION
Includes a Dockerfile for each service, and a docker-compose to
manage all services together.

Start by running "docker-compose up -d".
